### PR TITLE
Return path fix

### DIFF
--- a/email_check.module
+++ b/email_check.module
@@ -29,7 +29,7 @@ function email_check_mail_alter(&$message) {
     $site_mail_domain = variable_get('site_mail_domain', NULL);
     $site_mail_address = variable_get('site_mail', NULL);
     $site_reply_to = variable_get('site_replyto_mail', variable_get('site_mail'));
-    $site_return_path = variable_get('site_mail_return_path', variable_get('site_mail'));
+    $site_return_path = variable_get('site_mail_return_path', NULL);
 
     $site_mail_domain = empty($site_mail_domain) ? 'campaignion.org' : $site_mail_domain;
     $site_mail_address = empty($site_mail_address) ? 'info@campaignion.org' : $site_mail_address;
@@ -117,13 +117,20 @@ function email_check_mail_alter(&$message) {
   // We want to be able to specify a specific Return-Path. The header will be
   // extracted by the mail engine and passed to the sendmail command as `-f`
   // parameter.
-  if (empty($message['headers']['Return-Path']) || strpos($message['headers']['Return-Path'], '@' . $site_mail_domain) === FALSE) {
-    // Set a default Return-Path if none is set or it is invalid.
+  if ($site_return_path) {
+    // Set a the configured Return-Path if it is configured.
     $message['headers']['Return-Path'] = $site_return_path;
+  } elseif (empty($message['headers']['Return-Path'])) {
+    $message['headers']['Return-Path'] = $site_mail_address;
   }
+  // If the Return-Path is not in the mail domain, substitute it with the site_mail.
   if (strpos($message['headers']['Return-Path'], '@' . $site_mail_domain) === FALSE) {
-    // If the Return-Path is still invalid remove it.
-    unset($message['headers']['Return-Path']);
+    $message['headers']['Return-Path'] = $site_mail_address;
+    watchdog('email_check', 'The site return path "%returnpath" does not match the mail domain "%domain".  Rewrote to "%sitemail".', [
+      '%returnpath' => $site_return_path,
+      '%domain' => $site_mail_domain,
+      '%sitemail' => $site_mail_address,
+    ], WATCHDOG_NOTICE);
   }
 }
 

--- a/tests/MailAlterTest.php
+++ b/tests/MailAlterTest.php
@@ -236,6 +236,24 @@ class MailAlterTest extends \DrupalUnitTestCase {
   }
 
   /**
+   * Test mail will be sent if an addresses is found.
+   */
+  public function testNotNoSendingWhenAddresses() {
+    $message['from'] = 'site@example.com';
+    email_check_mail_alter($message);
+    $this->assertArrayNotHasKey('send', $message);
+  }
+
+  /**
+   * Test mail will not be sent if no addresses found.
+   */
+  public function testNoSendingWhenNoAddresses() {
+    $message['from'] = 'not-an-mail-address, this one @neither.com';
+    email_check_mail_alter($message);
+    $this->assertEqual(FALSE, $message['send']);
+  }
+
+  /**
    * Test the mail address matching regexp.
    */
   public function testSimpleFromAddressMatching() {

--- a/tests/MailAlterTest.php
+++ b/tests/MailAlterTest.php
@@ -94,14 +94,30 @@ class MailAlterTest extends \DrupalUnitTestCase {
   }
 
   /**
-   * Return-Path is only set when in mail domain. Default is the site_mail.
+   * A invalid return path is changed to the site mail.
+   *
+   * When no site_mail_return_path is set.
    */
-  public function testOnlyReturnPathFromMailDomain() {
+  public function testInvalidReturnPathChangedToSiteMail() {
     $message['from'] = 'some@example.com';
     $message['headers']['Return-Path'] = 'return@other.com';
     email_check_mail_alter($message);
     $this->assertEqual('some@example.com', $message['from']);
     $this->assertEqual('site@example.com', $message['headers']['Return-Path']);
+  }
+
+  /**
+   * A invalid return path is changed to the site return path.
+   *
+   * When site_mail_return_path is set.
+   */
+  public function testInvalidReturnPathChangedToSiteReturnPath() {
+    $this->setConfig(['site_mail_return_path' => 'bounce@example.com']);
+    $message['from'] = 'some@example.com';
+    $message['headers']['Return-Path'] = 'return@other.com';
+    email_check_mail_alter($message);
+    $this->assertEqual('some@example.com', $message['from']);
+    $this->assertEqual('bounce@example.com', $message['headers']['Return-Path']);
   }
 
   /**


### PR DESCRIPTION
Fixes a wrong assumption about the input `$message` `email_check` receives in the normal case: `Return-Path` is set by default to the from address.

Also add test cases for yet not tested behaviour.